### PR TITLE
fix inspect.argspec bug with backward compatibility

### DIFF
--- a/voxelmorph/torch/modelio.py
+++ b/voxelmorph/torch/modelio.py
@@ -11,7 +11,10 @@ def store_config_args(func):
     model loading - see LoadableModel.
     """
 
-    attrs, varargs, varkw, defaults = inspect.getargspec(func)
+    if not hasattr(inspect, 'getargspec'):
+        attrs, varargs, varkw, defaults, kwonlyargs, kwonlydefaults, annotations = inspect.getfullargspec(func)
+    else:
+        attrs, varargs, varkw, defaults= inspect.getargspec(func)
 
     @functools.wraps(func)
     def wrapper(self, *args, **kwargs):


### PR DESCRIPTION
inspect.argspec is deprecated from Python 3.0 and not accessible for Python>3.10. This code will check if inspect contains the argspec attribute, if not, uses the getfullargspec() method. Not thoroughly tested.